### PR TITLE
Adding http-client implementation

### DIFF
--- a/scala-non-pure-fp-version/.scalafmt.conf
+++ b/scala-non-pure-fp-version/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = "2.0.0-RC4"
+align = more
+maxColumn = 120

--- a/scala-non-pure-fp-version/README.md
+++ b/scala-non-pure-fp-version/README.md
@@ -1,0 +1,8 @@
+# Scala-None-Pure-FP-Version
+- This is a simple implementation of the elevio article-reviewer app in scala
+- It's written in `FP` style but it's not effectful (not using effect system more than just `Either` and `Option`)
+
+## Usage
+- `$ sbt compile` # for compiling the sources of the project
+- `$ sbt test`    # for running the project's test suite
+- `$ sbt run`     # for running the main class of the project

--- a/scala-non-pure-fp-version/README.md
+++ b/scala-non-pure-fp-version/README.md
@@ -2,6 +2,11 @@
 - This is a simple implementation of the elevio article-reviewer app in scala
 - It's written in `FP` style but it's not effectful (not using effect system more than just `Either` and `Option`)
 
+## Requirements
+- Please provide `X_API_KEY` environment variable on your system with the value of your account's api-key
+- Please provide `AUTHORIZATION` environment variable on your system with the value of your account's authorization token
+- Please provide `API_ENDPOINT` environment variable on your system with the value of elevio's api-endpoint route
+
 ## Usage
 - `$ sbt compile` # for compiling the sources of the project
 - `$ sbt test`    # for running the project's test suite

--- a/scala-non-pure-fp-version/build.sbt
+++ b/scala-non-pure-fp-version/build.sbt
@@ -3,3 +3,16 @@ name := "scala-non-pure-fp-version"
 version := "0.1"
 
 scalaVersion := "2.12.8"
+
+val sttpVersion      = "1.6.0"
+val circeVersion     = "0.10.0"
+val scalaTestVersion = "3.0.8"
+
+libraryDependencies ++= Seq(
+  "com.softwaremill.sttp" %% "core"          % sttpVersion,
+  "io.circe"              %% "circe-core"    % circeVersion,
+  "io.circe"              %% "circe-generic" % circeVersion,
+  "io.circe"              %% "circe-parser"  % circeVersion,
+  "org.scalactic"         %% "scalactic"     % scalaTestVersion,
+  "org.scalatest"         %% "scalatest"     % scalaTestVersion % "test"
+)

--- a/scala-non-pure-fp-version/src/main/scala/NonePureFPRunner.scala
+++ b/scala-non-pure-fp-version/src/main/scala/NonePureFPRunner.scala
@@ -1,0 +1,22 @@
+import application.adapters.http_client.sttp_http_client.{
+  GetAllArticlesClient,
+  GetArticleWithIdClient,
+  GetArticleWithKeywordClient
+}
+import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, SttpBackend}
+import domain.entity.Config
+
+object NonePureFPRunner extends App {
+  implicit val config: Config = Config(
+    Map(
+      "x-api-key"     -> sys.env("X_API_KEY"),
+      "Authorization" -> sys.env("AUTHORIZATION")
+    ),
+    sys.env("API_ENDPOINT")
+  )
+  implicit val httpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+
+  println(GetAllArticlesClient().process.currentResult.toString)
+  println(GetArticleWithIdClient(4).process.currentResult.toString)
+  println(GetArticleWithKeywordClient("Scala").process.currentResult.toString)
+}

--- a/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/GenericHttpClient.scala
+++ b/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/GenericHttpClient.scala
@@ -1,0 +1,29 @@
+package application.adapters.http_client
+
+import domain.entity.Article.{ArticleObj, ArticleRef, ArticleSearchResultObj}
+import domain.entity.Error.{
+  HttpFetchingAllArticlesError,
+  HttpFetchingArticleError,
+  HttpFetchingArticleSearchResultError
+}
+
+object GenericHttpClient {
+  type AllArticlesResult   = Either[HttpFetchingAllArticlesError, List[ArticleRef]]
+  type ArticleObject       = Either[HttpFetchingArticleError, ArticleObj]
+  type ArticleSearchResult = Either[HttpFetchingArticleSearchResultError, List[ArticleSearchResultObj]]
+
+  trait GetAllArticles {
+    val currentPage: Int
+    def process: AllArticlesResult
+  }
+
+  trait GetArticleById {
+    val id: Int
+    def process: ArticleObject
+  }
+
+  trait GetArticleByKeyword {
+    val keyword: String
+    def process: ArticleSearchResult
+  }
+}

--- a/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetAllArticlesClient.scala
+++ b/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetAllArticlesClient.scala
@@ -1,0 +1,42 @@
+package application.adapters.http_client.sttp_http_client
+
+import application.adapters.http_client.GenericHttpClient.{AllArticlesResult, GetAllArticles}
+import com.softwaremill.sttp._
+import domain.entity.Article.ArticleRef
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingAllArticlesError
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+
+final case class GetAllArticlesClient(
+    currentPage: Int = 1,
+    currentResult: AllArticlesResult = Right(List.empty)
+)(implicit val config: Config, implicit val httpBackend: SttpBackend[Id, Nothing]) {
+  private final case class Implementation(currentPage: Int) extends GetAllArticles {
+    val httpRequest: Request[String, Nothing] =
+      sttp
+        .headers(config.httpClientHeaders)
+        .get(uri"${config.apiEndpoint}/articles?page=$currentPage")
+
+    override def process: AllArticlesResult = {
+      try {
+        val response: Id[Response[String]]             = httpRequest.send()
+        val doc: Json                                  = parse(response.unsafeBody).getOrElse(Json.Null)
+        val cursor: HCursor                            = doc.hcursor
+        val articles: Decoder.Result[List[ArticleRef]] = cursor.downField("articles").as[List[ArticleRef]]
+
+        articles.fold(
+          _ => Left(HttpFetchingAllArticlesError()),
+          values => Right(values)
+        )
+      } catch {
+        case _: Throwable => Left(HttpFetchingAllArticlesError())
+      }
+    }
+  }
+
+  def process      = GetAllArticlesClient(currentPage, Implementation(currentPage).process)
+  def nextPage     = GetAllArticlesClient(currentPage + 1, Implementation(currentPage + 1).process)
+  def previousPage = GetAllArticlesClient(currentPage - 1, Implementation(currentPage - 1).process)
+}

--- a/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetArticleWithIdClient.scala
+++ b/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetArticleWithIdClient.scala
@@ -1,0 +1,40 @@
+package application.adapters.http_client.sttp_http_client
+
+import application.adapters.http_client.GenericHttpClient.{ArticleObject, GetArticleById}
+import com.softwaremill.sttp._
+import domain.entity.Article.ArticleObj
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingArticleError
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+
+final case class GetArticleWithIdClient(
+    id: Int,
+    currentResult: ArticleObject = Left(HttpFetchingArticleError())
+)(implicit val config: Config, implicit val httpBackend: SttpBackend[Id, Nothing]) {
+  private final case class Implementation(id: Int) extends GetArticleById {
+    val httpRequest: Request[String, Nothing] =
+      sttp
+        .headers(config.httpClientHeaders)
+        .get(uri"${config.apiEndpoint}/articles/$id")
+
+    override def process: ArticleObject = {
+      try {
+        val response: Id[Response[String]]       = httpRequest.send()
+        val doc: Json                            = parse(response.unsafeBody).getOrElse(Json.Null)
+        val cursor: HCursor                      = doc.hcursor
+        val articles: Decoder.Result[ArticleObj] = cursor.downField("article").as[ArticleObj]
+
+        articles.fold(
+          _ => Left(HttpFetchingArticleError()),
+          article => Right(article)
+        )
+      } catch {
+        case _: Throwable => Left(HttpFetchingArticleError())
+      }
+    }
+  }
+
+  def process = GetArticleWithIdClient(id, Implementation(id).process)
+}

--- a/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetArticleWithKeywordClient.scala
+++ b/scala-non-pure-fp-version/src/main/scala/application/adapters/http_client/sttp_http_client/GetArticleWithKeywordClient.scala
@@ -1,0 +1,40 @@
+package application.adapters.http_client.sttp_http_client
+
+import application.adapters.http_client.GenericHttpClient.{ArticleSearchResult, GetArticleByKeyword}
+import com.softwaremill.sttp._
+import domain.entity.Article.ArticleSearchResultObj
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingArticleSearchResultError
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+
+final case class GetArticleWithKeywordClient(
+    keyword: String,
+    currentResult: ArticleSearchResult = Right(List.empty)
+)(implicit val config: Config, implicit val httpBackend: SttpBackend[Id, Nothing]) {
+  private final case class Implementation(keyword: String) extends GetArticleByKeyword {
+    val httpRequest: Request[String, Nothing] =
+      sttp
+        .headers(config.httpClientHeaders)
+        .get(uri"${config.apiEndpoint}/search/en?query=$keyword")
+
+    override def process: ArticleSearchResult = {
+      try {
+        val response: Id[Response[String]] = httpRequest.send()
+        val doc: Json                      = parse(response.unsafeBody).getOrElse(Json.Null)
+        val cursor: HCursor                = doc.hcursor
+        val searchResult                   = cursor.downField("results").as[List[ArticleSearchResultObj]]
+
+        searchResult.fold(
+          _ => Left(HttpFetchingArticleSearchResultError()),
+          searchResult => Right(searchResult)
+        )
+      } catch {
+        case _: Throwable => Left(HttpFetchingArticleSearchResultError())
+      }
+    }
+  }
+
+  def process = GetArticleWithKeywordClient(keyword, Implementation(keyword).process)
+}

--- a/scala-non-pure-fp-version/src/main/scala/domain/entity/Article.scala
+++ b/scala-non-pure-fp-version/src/main/scala/domain/entity/Article.scala
@@ -1,0 +1,22 @@
+package domain.entity
+
+object Article {
+  final case class Author(id: Int, name: String, email: String)
+  final case class TranslationObj(summary: Option[String], body: String)
+
+  final case class ArticleRef(
+      id: Int,
+      title: String,
+      notes: Option[String],
+      keywords: List[String],
+      updated_at: String
+  )
+  final case class ArticleObj(
+      id: Int,
+      author: Author,
+      created_at: String,
+      title: String,
+      translations: List[TranslationObj]
+  )
+  final case class ArticleSearchResultObj(id: Int)
+}

--- a/scala-non-pure-fp-version/src/main/scala/domain/entity/Config.scala
+++ b/scala-non-pure-fp-version/src/main/scala/domain/entity/Config.scala
@@ -1,0 +1,3 @@
+package domain.entity
+
+final case class Config(httpClientHeaders: Map[String, String], apiEndpoint: String)

--- a/scala-non-pure-fp-version/src/main/scala/domain/entity/Error.scala
+++ b/scala-non-pure-fp-version/src/main/scala/domain/entity/Error.scala
@@ -1,0 +1,15 @@
+package domain.entity
+
+object Error {
+  case class HttpFetchingAllArticlesError() {
+    val cause: String = "Error http fetching all articles"
+  }
+
+  case class HttpFetchingArticleError() {
+    val cause: String = "Error http fetching article"
+  }
+
+  case class HttpFetchingArticleSearchResultError() {
+    val cause: String = "Error http fetching article search result"
+  }
+}

--- a/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetAllArticlesClient.scala
+++ b/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetAllArticlesClient.scala
@@ -1,0 +1,44 @@
+package application.http_client.sttp_http_client
+
+import application.adapters.http_client.sttp_http_client.GetAllArticlesClient
+import com.softwaremill.sttp.Id
+import com.softwaremill.sttp.testing.SttpBackendStub
+import domain.entity.Article.ArticleRef
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingAllArticlesError
+import org.scalatest.FunSuite
+
+class TestGetAllArticlesClient extends FunSuite {
+  val id          = 1
+  val title       = "test!"
+  val notes       = "note!"
+  val updatedAt   = "26/6/2019"
+  val apiEndpoint = "/articles"
+
+  test("calling /articles as valid response to get Right(List[ArticleRef])") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(
+          s""" {"articles": [{"id": $id, "title": "$title", "notes": "$notes", "keywords": [], "updated_at": "$updatedAt"}]} """
+        )
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    val actual = GetAllArticlesClient().process.currentResult
+
+    assertResult(Right(List(ArticleRef(id, title, Some(notes), List.empty, updatedAt))))(actual)
+    assertResult(3)(GetAllArticlesClient().process.nextPage.nextPage.nextPage.previousPage.currentPage)
+  }
+
+  test("calling /articles as invalid response to get Left(HttpFetchingAllArticlesError)") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(
+          s""" {"invalid": ""} """
+        )
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    assertResult(Left(HttpFetchingAllArticlesError()))(GetAllArticlesClient().process.currentResult)
+  }
+}

--- a/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetArticleByIdClient.scala
+++ b/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetArticleByIdClient.scala
@@ -1,0 +1,55 @@
+package application.http_client.sttp_http_client
+
+import application.adapters.http_client.sttp_http_client.GetArticleWithIdClient
+import com.softwaremill.sttp.Id
+import com.softwaremill.sttp.testing.SttpBackendStub
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingArticleError
+import org.scalatest.FunSuite
+
+class TestGetArticleByIdClient extends FunSuite {
+  val id          = 1
+  val name        = "test"
+  val email       = "test@test.test"
+  val createdAt   = "9/7/2019"
+  val title       = "test"
+  val summary     = "test"
+  val body        = "test"
+  val apiEndpoint = s"/articles/$id"
+
+  test(s"calling /articles/$id as valid response to get Right(ArticleObj)") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(
+          s""" {"article": {"id": $id, "author": {"id": $id, "name": "$name", "email": "$email"},"created_at": "$createdAt","title": "$title","translations": [{"summary": "$summary", "body": "$body"}]}} """
+        )
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    val actual = GetArticleWithIdClient(id).process.currentResult
+    actual match {
+      case Right(article) =>
+        assertResult(id)(article.id)
+        assertResult(name)(article.author.name)
+        assertResult(email)(article.author.email)
+        assertResult(createdAt)(article.created_at)
+        assertResult(title)(article.title)
+        assertResult(Some(summary))(article.translations.head.summary)
+        assertResult(body)(article.translations.head.body)
+      case Left(_) => fail("This should never happen in this test")
+    }
+  }
+
+  test(s"calling /articles/$id as invalid response to get Left(HttpFetchingArticleError)") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(
+          s""" {"invalid": "invalid"} """
+        )
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    val actual = GetArticleWithIdClient(id).process.currentResult
+    assertResult(Left(HttpFetchingArticleError()))(actual)
+  }
+}

--- a/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetArticleByKeywordClient.scala
+++ b/scala-non-pure-fp-version/src/test/scala/application/http_client/sttp_http_client/TestGetArticleByKeywordClient.scala
@@ -1,0 +1,41 @@
+package application.http_client.sttp_http_client
+
+import application.adapters.http_client.sttp_http_client.GetArticleWithKeywordClient
+import com.softwaremill.sttp.Id
+import com.softwaremill.sttp.testing.SttpBackendStub
+import domain.entity.Config
+import domain.entity.Error.HttpFetchingArticleSearchResultError
+import org.scalatest.FunSuite
+
+class TestGetArticleByKeywordClient extends FunSuite {
+  val id          = 1
+  val keyword     = "Scala"
+  val apiEndpoint = s"/articles/$id"
+
+  test(s"calling /articles/$id as valid response to get Right(ArticleObj)") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(s""" {"results": [{"id": $id}]} """)
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    val actual = GetArticleWithKeywordClient(keyword).process.currentResult
+    actual match {
+      case Right(article) => assertResult(id)(article.head.id)
+      case Left(_)        => fail("This should never happen in this test")
+    }
+  }
+
+  test(s"calling /articles/$id as invalid response to get Left(HttpFetchingArticleError)") {
+    implicit val httpBackend: SttpBackendStub[Id, Nothing] =
+      SttpBackendStub.synchronous
+        .whenRequestMatches(_ => true)
+        .thenRespond(
+          s""" {"invalid": "invalid"} """
+        )
+    implicit val config: Config = Config(Map.empty, apiEndpoint)
+
+    val actual = GetArticleWithKeywordClient(keyword).process.currentResult
+    assertResult(Left(HttpFetchingArticleSearchResultError()))(actual)
+  }
+}


### PR DESCRIPTION
Adding http-client implementation for
- Fetching all articles of the account considering result pages.
- Fetching all articles of the account containing a specific keyword.
- Fetching a specific article by it's id.